### PR TITLE
Fixed compilation errors

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2016,7 +2016,7 @@ bool CBlock::AddToBlockIndex(unsigned int nFile, unsigned int nBlockPos)
 
     // IncaKoin: restrict maximum reorganization depth
     if (pindexNew->GetBlockTime() > FORKTIME_REORG_PROTO_CHANGES && nBestHeight - pindexNew->nHeight > MAX_REORG_DEPTH)
-        return error("AddToBlockIndex() : %s failed because reorg of %d blocks is too deep", hash.GetHex(), nBestHeight - pindexNew->nHeight);
+        return error("AddToBlockIndex() : %s failed because reorg of %d blocks is too deep", hash.GetHex().c_str(), nBestHeight - pindexNew->nHeight);
 
     // ppcoin: compute chain trust score
     pindexNew->bnChainTrust = (pindexNew->pprev ? pindexNew->pprev->bnChainTrust : 0) + pindexNew->GetBlockTrust();


### PR DESCRIPTION
C isn't really aware of C++ structures so this change is needed in order for the program to compile.