### PR TITLE
Fix null value being fed into GetProofOfWorkReward() in PoW Miner code.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2016,7 +2016,7 @@ bool CBlock::AddToBlockIndex(unsigned int nFile, unsigned int nBlockPos)
 
     // IncaKoin: restrict maximum reorganization depth
     if (pindexNew->GetBlockTime() > FORKTIME_REORG_PROTO_CHANGES && nBestHeight - pindexNew->nHeight > MAX_REORG_DEPTH)
-        return error("AddToBlockIndex() : %s failed because reorg of %d blocks is too deep", hash.GetHex(), nBestHeight - pindexNew->nHeight);
+        return error("AddToBlockIndex() : %s failed because reorg of %d blocks is too deep", hash.GetHex().c_str(), nBestHeight - pindexNew->nHeight);
 
     // ppcoin: compute chain trust score
     pindexNew->bnChainTrust = (pindexNew->pprev ? pindexNew->pprev->bnChainTrust : 0) + pindexNew->GetBlockTrust();
@@ -4299,7 +4299,7 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake)
             printf("CreateNewBlock(): total size %"PRI64u"\n", nBlockSize);
 
         if (pblock->IsProofOfWork())
-            pblock->vtx[0].vout[0].nValue = GetProofOfWorkReward(pindexPrev->nHeight+1, nFees, pindexPrev->GetBlockHash(), pblock->GetBlockTime());
+            pblock->vtx[0].vout[0].nValue = GetProofOfWorkReward(pindexPrev->nHeight+1, nFees, pindexPrev->GetBlockHash(), GetAdjustedTime());
 
 
         // Fill in header


### PR DESCRIPTION
The internal wallet miner code was feeding a null value for time into the GetProofOfWorkReward() function. The GetProofOfWorkReward() function uses the time value to determine whether a new reward should be used. Since the value was 0, it was not triggered to use the new reward.

This update does not require a protocol update. Miners should upgrade to this code to get the proper reward when they mine a block.